### PR TITLE
Add .mpg and .mpeg to valid video file extensions

### DIFF
--- a/elodie/media/video.py
+++ b/elodie/media/video.py
@@ -32,7 +32,7 @@ class Video(Media):
     __name__ = 'Video'
 
     #: Valid extensions for video files.
-    extensions = ('avi', 'm4v', 'mov', 'mp4', '3gp')
+    extensions = ('avi', 'm4v', 'mov', 'mp4', 'mpg', 'mpeg', '3gp')
 
     def __init__(self, source=None):
         super(Video, self).__init__(source)


### PR DESCRIPTION
Resolves #84. I've tested that this works with both .MPG and .MPEG files.