### PR TITLE
Prevent crashing when place_name is a string

### DIFF
--- a/elodie/filesystem.py
+++ b/elodie/filesystem.py
@@ -274,7 +274,10 @@ class FileSystem(object):
             )
 
         if(not found and folder_name == ''):
-            folder_name = place_name['default']
+            if(isinstance(place_name, str)):
+                folder_name = place_name
+            else:
+                folder_name = place_name['default']            
 
         return folder_name
 


### PR DESCRIPTION
place_name is sometimes a string "Unknown Location" instead of a dictionary. Causing the script to error and stop processing.