### PR TITLE
Use bash as Docker's executable command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,19 +8,6 @@ RUN apt-get update -y && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
-# RUN apk add --update boost-python ca-certificates exiftool exiv2 make python py-pip && \
-#     pip install --upgrade pip setuptools && \
-#     apk add --virtual build-dependencies build-base boost-dev exiv2-dev python-dev scons wget && \
-#     wget -O /tmp/pyexiv2-0.3.2.tar.bz2 https://launchpad.net/pyexiv2/0.3.x/0.3.2/+download/pyexiv2-0.3.2.tar.bz2 && \
-#     echo "9c0377ca4cf7d5ceeee994af0b5536ae  /tmp/pyexiv2-0.3.2.tar.bz2" | md5sum -c - && \
-#     tar -C /tmp -xjf /tmp/pyexiv2-0.3.2.tar.bz2 && \
-#     rm -f /tmp/pyexiv2-0.3.2.tar.bz2 && \
-#     cd /tmp/pyexiv2-0.3.2 && \
-#     scons && \
-#     scons install && \
-#     cd / && \
-#     rm -rf /tmp/*
-
 COPY requirements.txt /opt/elodie/requirements.txt
 COPY docs/requirements.txt /opt/elodie/docs/requirements.txt
 COPY elodie/tests/requirements.txt /opt/elodie/elodie/tests/requirements.txt
@@ -31,4 +18,4 @@ RUN pip install -r docs/requirements.txt && \
 
 COPY . /opt/elodie
 
-CMD ["/bin/sh"]
+CMD ["/bin/bash"]


### PR DESCRIPTION
Change `sh` to `bash`, as `sh` is provided by `dash` in Debian, and it lacks
some features (like arrows movement) that makes it easier to use elodie from
the shell