### PR TITLE
fix problem when no geolocation key is provided #214

### DIFF
--- a/elodie/geolocation.py
+++ b/elodie/geolocation.py
@@ -146,6 +146,8 @@ def place_name(lat, lon):
                 #  set the most specific as the default.
                 if('default' not in lookup_place_name):
                     lookup_place_name['default'] = address[loc]
+
+    if(lookup_place_name):
         db.add_location(lat, lon, lookup_place_name)
         # TODO: Maybe this should only be done on exit and not for every write.
         db.update_location_db()

--- a/elodie/geolocation.py
+++ b/elodie/geolocation.py
@@ -146,8 +146,6 @@ def place_name(lat, lon):
                 #  set the most specific as the default.
                 if('default' not in lookup_place_name):
                     lookup_place_name['default'] = address[loc]
-
-    if(lookup_place_name is not {}):
         db.add_location(lat, lon, lookup_place_name)
         # TODO: Maybe this should only be done on exit and not for every write.
         db.update_location_db()


### PR DESCRIPTION
When there is no MapQuest key provided in ~/elodie/config.ini. There will still be a db.add_location of an empty result

So the next cached result will be empty and there will not be an place_name['default'] key.

So i guess this can be the root cause of the problem in issue #214. Although a key is provided in the issue this could be saved in script folder maybe