### PR TITLE
Bug with setting full_path variables in config.ini

### DIFF
--- a/elodie/filesystem.py
+++ b/elodie/filesystem.py
@@ -196,20 +196,18 @@ class FileSystem(object):
 
         self.cached_folder_path_definition = []
         for part in path_parts:
+            part = part.replace('%', '')
             if part in config_directory:
-                part = part[1:]
                 self.cached_folder_path_definition.append(
                     [(part, config_directory[part])]
                 )
             elif part in self.default_parts:
-                part = part[1:]
                 self.cached_folder_path_definition.append(
                     [(part, '')]
                 )
             else:
                 this_part = []
                 for p in part.split('|'):
-                    p = p[1:]
                     this_part.append(
                         (p, config_directory[p] if p in config_directory else '')
                     )

--- a/elodie/tests/filesystem_test.py
+++ b/elodie/tests/filesystem_test.py
@@ -707,7 +707,7 @@ def test_get_folder_path_definition_default():
     if hasattr(load_config, 'config'):
         del load_config.config
 
-    assert path_definition == [[('date', '%Y-%m-%b')], [('album', ''), ('location', '%city'), ('Unknown Location"', '')]], path_definition
+    assert path_definition == [[('date', '%Y-%m-%b')], [('album', ''), ('location', '%city'), ('"Unknown Location"', '')]], path_definition
 
 @mock.patch('elodie.config.config_file', '%s/config.ini-date-location' % gettempdir())
 def test_get_folder_path_definition_date_location():


### PR DESCRIPTION
When I try to set my own folder structure with config.ini, some settings are not working.
This config is not working.
`location=%city, %state`
`month=%B`
`year=%Y`
`full_path=%year/%month/%location`
`# -> 2015/December/Sunnyvale, California`
The reason is because `if part in config_directory:` will never be true. This will try to compare %year in variable part with year in variable config_directory.
So therefore, remove the % sign, which is removed later anyway