### PR TITLE
Fixes #237, destination timestamps set instead of source

### DIFF
--- a/elodie/filesystem.py
+++ b/elodie/filesystem.py
@@ -383,23 +383,20 @@ class FileSystem(object):
             os.utime(dest_path, (stat.st_atime, stat.st_mtime))
         else:
             compatability._copyfile(_file, dest_path)
-            self.set_utime(media, dest_path)
+            self.set_utime_from_metadata(media.get_metadata(), dest_path)
 
         db.add_hash(checksum, dest_path)
         db.update_hash_db()
 
         return dest_path
 
-    def set_utime(self, media, file_path=None):
+    def set_utime_from_metadata(self, metadata, file_path):
         """ Set the modification time on the file based on the file name.
         """
 
         # Initialize date taken to what's returned from the metadata function.
         # If the folder and file name follow a time format of
         #   YYYY-MM-DD_HH-MM-SS-IMG_0001.JPG then we override the date_taken
-        if not file_path:
-            file_path = media.get_file_path()
-        metadata = media.get_metadata()
         date_taken = metadata['date_taken']
         base_name = metadata['base_name']
         year_month_day_match = re.search(

--- a/elodie/filesystem.py
+++ b/elodie/filesystem.py
@@ -383,21 +383,22 @@ class FileSystem(object):
             os.utime(dest_path, (stat.st_atime, stat.st_mtime))
         else:
             compatability._copyfile(_file, dest_path)
-            self.set_utime(media)
+            self.set_utime(media, dest_path)
 
         db.add_hash(checksum, dest_path)
         db.update_hash_db()
 
         return dest_path
 
-    def set_utime(self, media):
+    def set_utime(self, media, file_path=None):
         """ Set the modification time on the file based on the file name.
         """
 
         # Initialize date taken to what's returned from the metadata function.
         # If the folder and file name follow a time format of
         #   YYYY-MM-DD_HH-MM-SS-IMG_0001.JPG then we override the date_taken
-        file_path = media.get_file_path()
+        if not file_path:
+            file_path = media.get_file_path()
         metadata = media.get_metadata()
         date_taken = metadata['date_taken']
         base_name = metadata['base_name']

--- a/elodie/tests/filesystem_test.py
+++ b/elodie/tests/filesystem_test.py
@@ -656,7 +656,7 @@ def test_set_utime_with_exif_date():
 
     assert initial_time != time.mktime(metadata_initial['date_taken'])
 
-    filesystem.set_utime(media_initial)
+    filesystem.set_utime(media_initial.get_metadata(), media_initial.get_file_path())
     final_stat = os.stat(origin)
     final_checksum = helper.checksum(origin)
 
@@ -685,7 +685,7 @@ def test_set_utime_without_exif_date():
 
     assert initial_time == time.mktime(metadata_initial['date_taken'])
 
-    filesystem.set_utime(media_initial)
+    filesystem.set_utime(media_initial.get_metadata(), media_initial.get_file_path())
     final_stat = os.stat(origin)
     final_checksum = helper.checksum(origin)
 

--- a/elodie/tests/filesystem_test.py
+++ b/elodie/tests/filesystem_test.py
@@ -656,7 +656,7 @@ def test_set_utime_with_exif_date():
 
     assert initial_time != time.mktime(metadata_initial['date_taken'])
 
-    filesystem.set_utime(media_initial.get_metadata(), media_initial.get_file_path())
+    filesystem.set_utime_from_metadata(media_initial.get_metadata(), media_initial.get_file_path())
     final_stat = os.stat(origin)
     final_checksum = helper.checksum(origin)
 
@@ -685,7 +685,7 @@ def test_set_utime_without_exif_date():
 
     assert initial_time == time.mktime(metadata_initial['date_taken'])
 
-    filesystem.set_utime(media_initial.get_metadata(), media_initial.get_file_path())
+    filesystem.set_utime_from_metadata(media_initial.get_metadata(), media_initial.get_file_path())
     final_stat = os.stat(origin)
     final_checksum = helper.checksum(origin)
 


### PR DESCRIPTION
Elodie, by default you copy my photos, but it looks like you then adjust the timestamps of the source not destination files!  Please do not adjust my source files, I would like these left untouched!

The function `process_file()` of `elodie/filesystem.py` applies `os.utime()` (via `set_utime()`, line 386) to the source file (determined from `media`), when it should be applied to the destination path stored in `dest_path`.

This branch fixes #237.