### PR TITLE
Make reset_dbs() / restore_dbs() more robust #260

### DIFF
--- a/elodie/compatability.py
+++ b/elodie/compatability.py
@@ -63,3 +63,13 @@ def _copyfile(src, dst):
             os.close(fout)
         except:
             pass
+
+
+# If you want cross-platform overwriting of the destination, 
+# use os.replace() instead of rename().
+# https://docs.python.org/3/library/os.html#os.rename
+def _rename(src, dst):
+    if (constants.python_version == 3):
+        return os.replace(src, dst)
+    else:
+        return os.rename(src, dst)

--- a/elodie/tests/helper.py
+++ b/elodie/tests/helper.py
@@ -14,6 +14,7 @@ import urllib
 from datetime import datetime
 from datetime import timedelta
 
+from elodie.compatability import _rename
 from elodie import constants
 
 def checksum(file_path, blocksize=65536):
@@ -153,7 +154,7 @@ def reset_dbs():
     if not os.path.isfile(hash_db):
 	    hash_db = constants.hash_db
 	    if os.path.isfile(hash_db):
-	        os.rename(hash_db, '{}-test'.format(hash_db))
+	        _rename(hash_db, '{}-test'.format(hash_db))
     #else restore_dbs wasn't called by a previous test, keep the
     #existing hash_db backup
 	
@@ -162,7 +163,7 @@ def reset_dbs():
     if os.path.isfile(location_db):
 	    location_db = constants.location_db
 	    if os.path.isfile(location_db):
-	        os.rename(location_db, '{}-test'.format(location_db))
+	        _rename(location_db, '{}-test'.format(location_db))
     #else restore_dbs wasn't called by a previous test, keep the
     #existing location_db backup
 
@@ -170,10 +171,8 @@ def restore_dbs():
     """ Restore back ups of hash_db and location_db """
     hash_db = '{}-test'.format(constants.hash_db)
     if os.path.isfile(hash_db):
-        # If you want cross-platform overwriting of the destination, 
-        # use os.replace() instead of rename().
-        os.replace(hash_db, hash_db.replace('-test', ''))
+        _rename(hash_db, hash_db.replace('-test', ''))
 
     location_db = '{}-test'.format(constants.location_db)
     if os.path.isfile(location_db):
-        os.replace(location_db, location_db.replace('-test', ''))
+        _rename(location_db, location_db.replace('-test', ''))

--- a/elodie/tests/helper.py
+++ b/elodie/tests/helper.py
@@ -148,19 +148,32 @@ def isclose(a, b, rel_tol = 1e-8):
             diff <= abs(rel_tol * b))
 
 def reset_dbs():
-    hash_db = constants.hash_db
-    if os.path.isfile(hash_db):
-        os.rename(hash_db, '{}-test'.format(hash_db))
-
-    location_db = constants.location_db
-    if os.path.isfile(location_db):
-        os.rename(location_db, '{}-test'.format(location_db))
-
-def restore_dbs():
+    """ Back up hash_db and location_db """
     hash_db = '{}-test'.format(constants.hash_db)
-    if os.path.isfile(hash_db):
-        os.rename(hash_db, hash_db.replace('-test', ''))
+    if not os.path.isfile(hash_db):
+	    hash_db = constants.hash_db
+	    if os.path.isfile(hash_db):
+	        os.rename(hash_db, '{}-test'.format(hash_db))
+    #else restore_dbs wasn't called by a previous test, keep the
+    #existing hash_db backup
+	
 
     location_db = '{}-test'.format(constants.location_db)
     if os.path.isfile(location_db):
-        os.rename(location_db, location_db.replace('-test', ''))
+	    location_db = constants.location_db
+	    if os.path.isfile(location_db):
+	        os.rename(location_db, '{}-test'.format(location_db))
+    #else restore_dbs wasn't called by a previous test, keep the
+    #existing location_db backup
+
+def restore_dbs():
+    """ Restore back ups of hash_db and location_db """
+    hash_db = '{}-test'.format(constants.hash_db)
+    if os.path.isfile(hash_db):
+        # If you want cross-platform overwriting of the destination, 
+        # use os.replace() instead of rename().
+        os.replace(hash_db, hash_db.replace('-test', ''))
+
+    location_db = '{}-test'.format(constants.location_db)
+    if os.path.isfile(location_db):
+        os.replace(location_db, location_db.replace('-test', ''))


### PR DESCRIPTION
If reset_dbs() is called and the test errors restore_dbs() is not called. On Windows this leads to an error the next time they're called because ~/hash.json-test and ~/location.json-test still exist.