### PR TITLE
Modify generate-db command help

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -154,8 +154,8 @@ Options:
 ```
 Usage: elodie.py generate-db [OPTIONS]
 
-  Regenerate the hash.json database which contains all of the sha1
-  signatures of media files.
+  Regenerate the hash.json database which contains all of the sha256
+  signatures of media files. The hash.json file is located at ~/.elodie/.
 
 Options:
   --source DIRECTORY  Source of your photo library.  [required]

--- a/elodie.py
+++ b/elodie.py
@@ -128,7 +128,7 @@ def _import(destination, source, file, album_from_folder, trash, allow_duplicate
 @click.option('--debug', default=False, is_flag=True,
               help='Override the value in constants.py with True.')
 def _generate_db(source, debug):
-    """Regenerate the hash.json database which contains all of the sha1 signatures of media files.
+    """Regenerate the hash.json database which contains all of the sha256 signatures of media files. The hash.json file is located at ~/.elodie/.
     """
     constants.debug = debug
     result = Result()


### PR DESCRIPTION
It wasn't clear to me at first where the hash.json was being stored. I was expecting the json file to be written to the source (root of the photo library). So I added to the help file that it actually gets written to ~/.elodie/.

Also noticed that elodie generates sha256 and not sha1. Minor detail but I tweaked it.