### PR TITLE
Start using HTTPS MapQuest API (stop using HTTP)

### DIFF
--- a/elodie/geolocation.py
+++ b/elodie/geolocation.py
@@ -177,7 +177,7 @@ def lookup(**kwargs):
         path = '/geocoding/v1/address'
         if('lat' in kwargs and 'lon' in kwargs):
             path = '/nominatim/v1/reverse.php'
-        url = 'http://open.mapquestapi.com%s?%s' % (
+        url = 'https://open.mapquestapi.com%s?%s' % (
                     path,
                     urllib.parse.urlencode(params)
               )


### PR DESCRIPTION
I noticed that the MapQuest API usage seemed to be HTTP rather than HTTPS. This security issue can cause your location information to be leaked.

The HTTPS endpoint seems to work fine. Have I possibly missed anything?