### PR TITLE
Add support for a %custom placeholder for more complex folder names than %location or %date provide #279

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/**
 **/*.dng
 **/*.nef
 **/*.rw2
+env/**

--- a/Readme.md
+++ b/Readme.md
@@ -195,6 +195,12 @@ month=%m
 year=%Y
 full_path=%year-%month/%location
 # -> 2015-12/Sunnyvale, California
+
+date=%Y
+location=%city, %state
+custom=%date %album
+full_path=%location/%custom
+# -> Sunnyvale, California/2015 Birthday Party
 ```
 
 #### Using fallback folders
@@ -239,6 +245,7 @@ In addition to my built-in and date placeholders you can combine them into a sin
 
 * `%location` can be used to combine multiple values of `%city`, `%state` and `%country`. For example, `location=%city, %state` would result in folder names like `Sunnyvale, California`.
 * `%date` can be used to combine multiple values from [the standard Python time directives](https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior). For example, `date=%Y-%m` would result in folder names like `2015-12`.
+* `%custom` can be used to combine multiple values from anything else. Think of it as a catch-all when `%location` and `%date` don't meet your needs.
 
 ### Reorganize by changing location and dates
 

--- a/elodie/filesystem.py
+++ b/elodie/filesystem.py
@@ -232,50 +232,15 @@ class FileSystem(object):
             #  Unknown Location - when neither an album nor location exist
             for this_part in path_part:
                 part, mask = this_part
-                this_path = self.dynamic_path(part, mask, metadata)
+                this_path = self.get_dynamic_path(part, mask, metadata)
                 if this_path:
                     path.append(this_path.strip())
                     # We break as soon as we have a value to append
                     # Else we continue for fallbacks
                     break
-                """
-                if part in ('date', 'day', 'month', 'year'):
-                    path.append(
-                        time.strftime(mask, metadata['date_taken'])
-                    )
-                    break
-                elif part in ('location', 'city', 'state', 'country'):
-                    place_name = geolocation.place_name(
-                        metadata['latitude'],
-                        metadata['longitude']
-                    )
-
-                    location_parts = re.findall('(%[^%]+)', mask)
-                    parsed_folder_name = self.parse_mask_for_location(
-                        mask,
-                        location_parts,
-                        place_name,
-                    )
-                    path.append(parsed_folder_name)
-                    break
-                elif part in ('custom'):
-                    custom_parts = re.findall('(%[a-z_]+)', mask)
-                    folder = mask
-                    for i in custom_parts:
-                        folder = folder.replace(i, metadata[i[1:]])
-                    path.append(folder)
-                    break
-                elif part in ('album', 'camera_make', 'camera_model'):
-                    if metadata[part]:
-                        path.append(metadata[part])
-                        break
-                elif part.startswith('"') and part.endswith('"'):
-                    path.append(part[1:-1])
-                """
-
         return os.path.join(*path)
 
-    def dynamic_path(self, part, mask, metadata):
+    def get_dynamic_path(self, part, mask, metadata):
         """Parse a specific folder's name given a mask and metadata.
 
         :param part: Name of the part as defined in the path (i.e. date from %date)
@@ -292,7 +257,7 @@ class FileSystem(object):
             for i in custom_parts:
                 folder = folder.replace(
                     i,
-                    self.dynamic_path(i[1:], i, metadata)
+                    self.get_dynamic_path(i[1:], i, metadata)
                 )
             return folder
         elif part in ('date'):

--- a/elodie/filesystem.py
+++ b/elodie/filesystem.py
@@ -223,6 +223,7 @@ class FileSystem(object):
         """
         path_parts = self.get_folder_path_definition()
         path = []
+        print('path_parts', path_parts)
         for path_part in path_parts:
             # We support fallback values so that
             #  'album|city|"Unknown Location"
@@ -231,8 +232,14 @@ class FileSystem(object):
             #  Sunnyvale - when no album exists but a city exists
             #  Unknown Location - when neither an album nor location exist
             for this_part in path_part:
+                print('this_part', this_part)
                 part, mask = this_part
-                path.append(self.dynamic_path_append(path, part, mask, metadata))
+                extra_path = self.dynamic_path_append(path, part, mask, metadata)
+                print('extra_path', extra_path)
+                if extra_path:
+                    path.append(extra_path)
+                    print('path', path)
+                    break
                 """
                 if part in ('date', 'day', 'month', 'year'):
                     path.append(
@@ -300,16 +307,19 @@ class FileSystem(object):
             )
 
             location_parts = re.findall('(%[^%]+)', mask)
+            print('location-part', mask, location_parts, place_name)
             parsed_folder_name = self.parse_mask_for_location(
                 mask,
                 location_parts,
                 place_name,
             )
+            print('location-part', parsed_folder_name)
             return parsed_folder_name
         elif part in ('album', 'camera_make', 'camera_model'):
             if metadata[part]:
                 return metadata[part]
         elif part.startswith('"') and part.endswith('"'):
+            # Fallback string
             return part[1:-1]
 
         return ''

--- a/elodie/tests/filesystem_test.py
+++ b/elodie/tests/filesystem_test.py
@@ -300,37 +300,32 @@ full_path=%custom
     assert path == '2015-12-Dec Test Album', path
 
 @mock.patch('elodie.config.config_file', '%s/config.ini-combined-date-album-location-fallback' % gettempdir())
-def test_get_folder_path_with_combined_date_album_and_location_fallback():
+def test_get_folder_path_with_album_and_location_fallback():
     # gh-279
-    with open('%s/config.ini-combined-date-album-location-fallback' % gettempdir(), 'w') as f:
+    with open('%s/config.ini-album-fallback' % gettempdir(), 'w') as f:
         f.write("""
 [Directory]
 date=%Y-%m-%b
-custom=%date %album|%city
-full_path=%custom
+custom=%album
+full_path=%custom|%city
         """)
     if hasattr(load_config, 'config'):
         del load_config.config
     filesystem = FileSystem()
 
-    # Test with Album
-    media = Photo(helper.get_file('with-album.jpg'))
+    # Test with no location
+    media = Photo(helper.get_file('plain.jpg'))
     path = filesystem.get_folder_path(media.get_metadata())
-    assert path == '2015-12-Dec Test Album', path
+    assert path == 'Unknown Location', path
 
     # Test with City
     media = Photo(helper.get_file('with-location.jpg'))
     path = filesystem.get_folder_path(media.get_metadata())
-    assert path == '2015-12-Dec Sunnyvale', path
-
-    # Test Plain
-    media = Photo(helper.get_file('plain.jpg'))
-    path = filesystem.get_folder_path(media.get_metadata())
-    assert path == '2015-12-Dec', path
-
-    # Clean-up
     if hasattr(load_config, 'config'):
         del load_config.config
+
+    assert path == 'Sunnyvale', path
+
 
 def test_get_folder_path_with_int_in_source_path():
     # gh-239

--- a/elodie/tests/filesystem_test.py
+++ b/elodie/tests/filesystem_test.py
@@ -266,18 +266,43 @@ def test_get_folder_path_with_int_in_config_component():
     with open('%s/config.ini-int-in-component-path' % gettempdir(), 'w') as f:
         f.write("""
 [Directory]
-date=%Y
-full_path=%date
+date=%Y-%m-%d
+full_path=%date/%album|"No Album"
         """)
     if hasattr(load_config, 'config'):
         del load_config.config
     filesystem = FileSystem()
-    media = Photo(helper.get_file('plain.jpg'))
+    media = Photo(helper.get_file('with-album.jpg'))
+    print(media.get_metadata())
     path = filesystem.get_folder_path(media.get_metadata())
     if hasattr(load_config, 'config'):
         del load_config.config
 
     assert path == os.path.join('2015'), path
+
+@mock.patch('elodie.config.config_file', '%s/config.ini-int-in-component-path' % gettempdir())
+def test_gh_279():
+    # gh-239
+    with open('%s/config.ini-int-in-component-path' % gettempdir(), 'w') as f:
+        f.write("""
+[Directory]
+month=%m
+year=%Y
+date=%m-%Y
+custom=%date %city
+full_path=%custom
+        """)
+    if hasattr(load_config, 'config'):
+        del load_config.config
+    filesystem = FileSystem()
+    media = Photo(helper.get_file('with-location.jpg'))
+    print(media.get_metadata())
+    path = filesystem.get_folder_path(media.get_metadata())
+    if hasattr(load_config, 'config'):
+        del load_config.config
+
+    print(path)
+    assert False and path == os.path.join('2015'), path
 
 def test_get_folder_path_with_int_in_source_path():
     # gh-239

--- a/elodie/tests/filesystem_test.py
+++ b/elodie/tests/filesystem_test.py
@@ -315,16 +315,16 @@ full_path=%custom|%city
 
     # Test with no location
     media = Photo(helper.get_file('plain.jpg'))
-    path = filesystem.get_folder_path(media.get_metadata())
-    assert path == 'Unknown Location', path
+    path_plain = filesystem.get_folder_path(media.get_metadata())
 
     # Test with City
     media = Photo(helper.get_file('with-location.jpg'))
-    path = filesystem.get_folder_path(media.get_metadata())
+    path_city = filesystem.get_folder_path(media.get_metadata())
     if hasattr(load_config, 'config'):
         del load_config.config
 
-    assert path == 'Sunnyvale', path
+    assert path_plain == 'Unknown Location', path
+    assert path_city == 'Sunnyvale', path
 
 
 def test_get_folder_path_with_int_in_source_path():

--- a/elodie/tests/filesystem_test.py
+++ b/elodie/tests/filesystem_test.py
@@ -323,8 +323,8 @@ full_path=%custom|%city
     if hasattr(load_config, 'config'):
         del load_config.config
 
-    assert path_plain == 'Unknown Location', path
-    assert path_city == 'Sunnyvale', path
+    assert path_plain == 'Unknown Location', path_plain
+    assert path_city == 'Sunnyvale', path_city
 
 
 def test_get_folder_path_with_int_in_source_path():

--- a/elodie/tests/filesystem_test.py
+++ b/elodie/tests/filesystem_test.py
@@ -302,7 +302,7 @@ full_path=%custom
 @mock.patch('elodie.config.config_file', '%s/config.ini-combined-date-album-location-fallback' % gettempdir())
 def test_get_folder_path_with_album_and_location_fallback():
     # gh-279
-    with open('%s/config.ini-album-fallback' % gettempdir(), 'w') as f:
+    with open('%s/config.ini-combined-date-album-location-fallback' % gettempdir(), 'w') as f:
         f.write("""
 [Directory]
 date=%Y-%m-%b


### PR DESCRIPTION
Addresses #279 

- [x] Add test for fallback support with `%custom` placeholder
- [x] Refactor nested / repeated check for `Directory` in config
- [x] Clean up commented out code
- [x] Rename `filesystem.dynamic_path_append` function
- [x] Add tests for `filesystem.dynamic_path_append` function
