### PR TITLE
Determine timezone offset for date_taken using latitude and longitude

### DIFF
--- a/elodie/media/base.py
+++ b/elodie/media/base.py
@@ -10,8 +10,13 @@ are used to represent the actual files.
 .. moduleauthor:: Jaisen Mathai <jaisen@jmathai.com>
 """
 
+import datetime
 import mimetypes
 import os
+import pytz
+from tzwhere.tzwhere import tzwhere
+
+from elodie.config import load_config
 
 try:        # Py3k compatibility
     basestring
@@ -39,6 +44,28 @@ class Base(object):
 
         :returns: dict
         """
+    def get_adjusted_date_taken(self):
+        """Returns date taken and adjust based on time zone if needed.
+        Time zone conversion is based on a configurable value from config.ini.
+
+        :returns: int
+        """
+        config = load_config()
+        metadata = self.get_metadata()
+        if(
+            'Timezone' in config and
+            'use_location' in config['Timezone'] and
+            config['Timezone'].getboolean('use_location') is True and
+            metadata['latitude'] is not None and
+            metadata['longitude'] is not None
+        ):
+            timezone_string = tzwhere().tzNameAt(
+                                metadata['latitude'],
+                                metadata['longitude']
+                            )
+            return timezone_string
+        return metadata['date_taken']
+
 
     def get_album(self):
         """Base method for getting an album

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ Send2Trash==1.3.0
 future==0.16.0
 configparser==3.5.0
 tabulate==0.7.7
+pytz==2019.1
+tzwhere==3.0.3
+numpy==1.16.3


### PR DESCRIPTION
Uses the `tzwhere` and `pytz` libraries to get the string representation of the location (i.e. US/Pacific) and converts that to an offset which is used to adjust the date related parameters when organizing files.