### PR TITLE
Make Pillow optional due to external dependencies

### DIFF
--- a/elodie/media/photo.py
+++ b/elodie/media/photo.py
@@ -103,11 +103,15 @@ class Photo(Media):
         # https://github.com/python-pillow/Pillow/issues/2806
         extension = os.path.splitext(source)[1][1:].lower()
         if(extension != 'heic'):
+            # gh-4 This checks if the source file is an image.
+            # It doesn't validate against the list of supported types.
+            # We check with imghdr and pillow.
             if(imghdr.what(source) is None):
-                # gh-4 This checks if the source file is an image.
-                # It doesn't validate against the list of supported types.
-                # We check with imghdr and pillow.
-                if(self.pillow is not None):
+                # Pillow is used as a fallback and if it's not available we trust
+                #   what imghdr returned.
+                if(self.pillow is None):
+                    return False
+                else:
                     # imghdr won't detect all variants of images (https://bugs.python.org/issue28591)
                     # see https://github.com/jmathai/elodie/issues/281
                     # before giving up, we use `pillow` imaging library to detect file type
@@ -124,7 +128,5 @@ class Photo(Media):
 
                     if(im.format is None):
                         return False
-                else:
-                    return False
         
         return extension in self.extensions

--- a/elodie/media/photo.py
+++ b/elodie/media/photo.py
@@ -12,9 +12,7 @@ import os
 import re
 import time
 from datetime import datetime
-from PIL import Image
 from re import compile
-
 
 from elodie import log
 from .media import Media
@@ -37,6 +35,15 @@ class Photo(Media):
 
         # We only want to parse EXIF once so we store it here
         self.exif = None
+
+        # Optionally import Pillow - see gh-325
+        # https://github.com/jmathai/elodie/issues/325
+        self.pillow = None
+        try:
+            from PIL import Image
+            self.pillow = Image
+        except ImportError:
+            pass
 
     def get_date_taken(self):
         """Get the date which the photo was taken.
@@ -96,24 +103,28 @@ class Photo(Media):
         # https://github.com/python-pillow/Pillow/issues/2806
         extension = os.path.splitext(source)[1][1:].lower()
         if(extension != 'heic'):
-            # gh-4 This checks if the source file is an image.
-            # It doesn't validate against the list of supported types.
             if(imghdr.what(source) is None):
-                # imghdr won't detect all variants of images (https://bugs.python.org/issue28591)
-                # see https://github.com/jmathai/elodie/issues/281
-                # before giving up, we use `pillow` imaging library to detect file type
-                #
-                # It is important to note that the library doesn't decode or load the
-                # raster data unless it really has to. When you open a file,
-                # the file header is read to determine the file format and extract
-                # things like mode, size, and other properties required to decode the file,
-                # but the rest of the file is not processed until later.
-                try:
-                    im = Image.open(source)
-                except IOError:
-                    return False
+                # gh-4 This checks if the source file is an image.
+                # It doesn't validate against the list of supported types.
+                # We check with imghdr and pillow.
+                if(self.pillow is not None):
+                    # imghdr won't detect all variants of images (https://bugs.python.org/issue28591)
+                    # see https://github.com/jmathai/elodie/issues/281
+                    # before giving up, we use `pillow` imaging library to detect file type
+                    #
+                    # It is important to note that the library doesn't decode or load the
+                    # raster data unless it really has to. When you open a file,
+                    # the file header is read to determine the file format and extract
+                    # things like mode, size, and other properties required to decode the file,
+                    # but the rest of the file is not processed until later.
+                    try:
+                        im = self.pillow.open(source)
+                    except IOError:
+                        return False
 
-                if(im.format is None):
+                    if(im.format is None):
+                        return False
+                else:
                     return False
-
+        
         return extension in self.extensions

--- a/elodie/tests/media/photo_test.py
+++ b/elodie/tests/media/photo_test.py
@@ -165,6 +165,11 @@ def test_is_valid_fallback_using_pillow():
 
     assert photo.is_valid()
 
+def test_pillow_not_loaded():
+    photo = Photo(helper.get_file('imghdr-error.jpg'))
+    photo.pillow = None
+
+    assert photo.is_valid() == False
 
 def test_set_album():
     temporary_folder, folder = helper.create_working_folder()


### PR DESCRIPTION
Fixes #325.

`Pillow` has a number of [external dependencies](https://pillow.readthedocs.io/en/5.2.x/installation.html#external-libraries) needed for installation. Since most media files are detected correctly with `imghdr` and `Pillow` is used as a fallback we can make it optional.

Pillow support was added in #320 to fix #281.