### PR TITLE
Fix Exception is raised when creating a media item in Google Photos fails #328

### DIFF
--- a/elodie/plugins/googlephotos/googlephotos.py
+++ b/elodie/plugins/googlephotos/googlephotos.py
@@ -149,7 +149,7 @@ class GooglePhotos(PluginBase):
             )
 
         ):
-            self.log('Creating new media item failed: {}'.format(resp['newMediaItemResults'][0]['status']))
+            self.log('Creating new media item failed: {}'.format(json.dumps(resp)))
             return None
         
         return resp['newMediaItemResults'][0]


### PR DESCRIPTION
Fixes #328 

When creating a new media item for Google Photos fails it does not return newMediaItemResults in the body. The code checks for this but then returns the key which it verified does not exist.

This change returns the entire response body in its entirety.