### PR TITLE
Fix issue where photos without EXIF were not using the correct date for folder or file names #330

### DIFF
--- a/elodie/filesystem.py
+++ b/elodie/filesystem.py
@@ -112,7 +112,7 @@ class FileSystem(object):
         """
         return os.getcwd()
 
-    def get_file_name(self, media):
+    def get_file_name(self, metadata):
         """Generate file name for a photo or video using its metadata.
 
         Originally we hardcoded the file name to include an ISO date format.
@@ -128,10 +128,6 @@ class FileSystem(object):
             :class:`~elodie.media.video.Video`
         :returns: str or None for non-photo or non-videos
         """
-        if(not media.is_valid()):
-            return None
-
-        metadata = media.get_metadata()
         if(metadata is None):
             return None
 
@@ -539,9 +535,8 @@ class FileSystem(object):
             return
 
         directory_name = self.get_folder_path(metadata)
-
         dest_directory = os.path.join(destination, directory_name)
-        file_name = self.get_file_name(media)
+        file_name = self.get_file_name(metadata)
         dest_path = os.path.join(dest_directory, file_name)
 
         media.set_original_name()

--- a/elodie/filesystem.py
+++ b/elodie/filesystem.py
@@ -519,6 +519,7 @@ class FileSystem(object):
             allow_duplicate = kwargs['allowDuplicate']
 
         stat_info_original = os.stat(_file)
+        metadata = media.get_metadata()
 
         if(not media.is_valid()):
             print('%s is not a valid media file. Skipping...' % _file)
@@ -537,14 +538,13 @@ class FileSystem(object):
             log.warn('At least one plugin pre-run failed for %s' % _file)
             return
 
-        media.set_original_name()
-        metadata = media.get_metadata()
-
         directory_name = self.get_folder_path(metadata)
 
         dest_directory = os.path.join(destination, directory_name)
         file_name = self.get_file_name(media)
         dest_path = os.path.join(dest_directory, file_name)
+
+        media.set_original_name()
 
         # If source and destination are identical then
         #  we should not write the file. gh-210

--- a/elodie/tests/filesystem_test.py
+++ b/elodie/tests/filesystem_test.py
@@ -207,35 +207,35 @@ name=%date-%original_name.%extension
 def test_get_file_name_plain():
     filesystem = FileSystem()
     media = Photo(helper.get_file('plain.jpg'))
-    file_name = filesystem.get_file_name(media)
+    file_name = filesystem.get_file_name(media.get_metadata())
 
     assert file_name == helper.path_tz_fix('2015-12-05_00-59-26-plain.jpg'), file_name
 
 def test_get_file_name_with_title():
     filesystem = FileSystem()
     media = Photo(helper.get_file('with-title.jpg'))
-    file_name = filesystem.get_file_name(media)
+    file_name = filesystem.get_file_name(media.get_metadata())
 
     assert file_name == helper.path_tz_fix('2015-12-05_00-59-26-with-title-some-title.jpg'), file_name
 
 def test_get_file_name_with_original_name_exif():
     filesystem = FileSystem()
     media = Photo(helper.get_file('with-filename-in-exif.jpg'))
-    file_name = filesystem.get_file_name(media)
+    file_name = filesystem.get_file_name(media.get_metadata())
 
     assert file_name == helper.path_tz_fix('2015-12-05_00-59-26-foobar.jpg'), file_name
 
 def test_get_file_name_with_original_name_title_exif():
     filesystem = FileSystem()
     media = Photo(helper.get_file('with-filename-and-title-in-exif.jpg'))
-    file_name = filesystem.get_file_name(media)
+    file_name = filesystem.get_file_name(media.get_metadata())
 
     assert file_name == helper.path_tz_fix('2015-12-05_00-59-26-foobar-foobar-title.jpg'), file_name
 
 def test_get_file_name_with_uppercase_and_spaces():
     filesystem = FileSystem()
     media = Photo(helper.get_file('Plain With Spaces And Uppercase 123.jpg'))
-    file_name = filesystem.get_file_name(media)
+    file_name = filesystem.get_file_name(media.get_metadata())
 
     assert file_name == helper.path_tz_fix('2015-12-05_00-59-26-plain-with-spaces-and-uppercase-123.jpg'), file_name
 
@@ -252,7 +252,7 @@ name=%date-%original_name.%extension
 
     filesystem = FileSystem()
     media = Photo(helper.get_file('plain.jpg'))
-    file_name = filesystem.get_file_name(media)
+    file_name = filesystem.get_file_name(media.get_metadata())
 
     if hasattr(load_config, 'config'):
         del load_config.config
@@ -272,7 +272,7 @@ name=%date-%original_name-%title.%extension
 
     filesystem = FileSystem()
     media = Photo(helper.get_file('with-title.jpg'))
-    file_name = filesystem.get_file_name(media)
+    file_name = filesystem.get_file_name(media.get_metadata())
 
     if hasattr(load_config, 'config'):
         del load_config.config
@@ -292,7 +292,7 @@ name=%date-%original_name-%title.%extension
 
     filesystem = FileSystem()
     media = Photo(helper.get_file('plain.jpg'))
-    file_name = filesystem.get_file_name(media)
+    file_name = filesystem.get_file_name(media.get_metadata())
 
     if hasattr(load_config, 'config'):
         del load_config.config
@@ -313,7 +313,7 @@ capitalization=lower
 
     filesystem = FileSystem()
     media = Photo(helper.get_file('plain.jpg'))
-    file_name = filesystem.get_file_name(media)
+    file_name = filesystem.get_file_name(media.get_metadata())
 
     if hasattr(load_config, 'config'):
         del load_config.config
@@ -334,7 +334,7 @@ capitalization=garabage
 
     filesystem = FileSystem()
     media = Photo(helper.get_file('plain.jpg'))
-    file_name = filesystem.get_file_name(media)
+    file_name = filesystem.get_file_name(media.get_metadata())
 
     if hasattr(load_config, 'config'):
         del load_config.config
@@ -355,7 +355,7 @@ capitalization=upper
 
     filesystem = FileSystem()
     media = Photo(helper.get_file('plain.jpg'))
-    file_name = filesystem.get_file_name(media)
+    file_name = filesystem.get_file_name(media.get_metadata())
 
     if hasattr(load_config, 'config'):
         del load_config.config

--- a/elodie/tests/filesystem_test.py
+++ b/elodie/tests/filesystem_test.py
@@ -787,6 +787,29 @@ def test_process_file_validate_original_checksum():
     assert origin_checksum_preprocess == origin_checksum, (origin_checksum_preprocess, origin_checksum)
 
 
+# See https://github.com/jmathai/elodie/issues/330
+def test_process_file_no_exif_date_is_correct_gh_330():
+    filesystem = FileSystem()
+    temporary_folder, folder = helper.create_working_folder()
+
+    origin = os.path.join(folder,'photo.jpg')
+    shutil.copyfile(helper.get_file('no-exif.jpg'), origin)
+
+    atime = 1330712100
+    utime = 1330712900
+    os.utime(origin, (atime, utime))
+
+    media = Photo(origin)
+    metadata = media.get_metadata()
+
+    destination = filesystem.process_file(origin, temporary_folder, media, allowDuplicate=True)
+
+    shutil.rmtree(folder)
+    shutil.rmtree(os.path.dirname(os.path.dirname(destination)))
+
+    assert '/2012-03-Mar/' in destination, destination
+    assert '/2012-03-02_18-28-20' in destination, destination
+
 def test_process_file_with_location_and_title():
     filesystem = FileSystem()
     temporary_folder, folder = helper.create_working_folder()


### PR DESCRIPTION
Fixes #330 

Fixes a bug in the code where `media.set_original_name()` would set the `mtime` of a photo and then use the newly set `mtime` for generating the folder and file name.