### PR TITLE
Set file modification time according to UTC

### DIFF
--- a/elodie/filesystem.py
+++ b/elodie/filesystem.py
@@ -10,6 +10,7 @@ import os
 import re
 import shutil
 import time
+import calendar
 
 from elodie import compatability
 from elodie import geolocation
@@ -628,5 +629,5 @@ class FileSystem(object):
         else:
             # We don't make any assumptions about time zones and
             # assume local time zone.
-            date_taken_in_seconds = time.mktime(date_taken)
+            date_taken_in_seconds = calendar.timegm(date_taken)
             os.utime(file_path, (time.time(), (date_taken_in_seconds)))


### PR DESCRIPTION
Since the `date_taken` metadata is UTC, we can use [calendar.timegm](https://docs.python.org/3/library/calendar.html#calendar.timegm) to update the file modification time according to the local timezone.

Currently, `mktime` is used which assumes a local datetime.
This is not the case, and because DST flag is always set to 0, the time offset is not even consistent.