### PR TITLE
Fix bug using bool to test prefer_english_names

### DIFF
--- a/elodie/geolocation.py
+++ b/elodie/geolocation.py
@@ -12,6 +12,7 @@ import requests
 import urllib.request
 import urllib.parse
 import urllib.error
+from distutils.util import strtobool
 
 from elodie.config import load_config
 from elodie import constants
@@ -135,7 +136,7 @@ def get_prefer_english_names():
     if('prefer_english_names' not in config['MapQuest']):
         return False
 
-    __PREFER_ENGLISH_NAMES__ = bool(config['MapQuest']['prefer_english_names'])
+    __PREFER_ENGLISH_NAMES__ = bool(strtobool(config['MapQuest']['prefer_english_names']))
     return __PREFER_ENGLISH_NAMES__
 
 def place_name(lat, lon):


### PR DESCRIPTION
Fixes a bug in [PR 290](https://github.com/jmathai/elodie/pull/290) and closes issue #369 (Prefer English names logic is broken).

`bool` cannot be used to test for a True or False string in python.

This uses the standard routine `distutils.util.strtobool` to check the string provided in config.ini.  This will correctly interpret: y, yes, t, true, on, 1, false, n, no, f, false, off, 0 and is case-insensitive.

I'm not sure how this slipped through the tests before...