### PR TITLE
Use -api QuickTimeUTC by default

### DIFF
--- a/elodie.py
+++ b/elodie.py
@@ -371,7 +371,9 @@ main.add_command(_batch)
 if __name__ == '__main__':
     #Initialize ExifTool Subprocess
     exiftool_addedargs = [
-       u'-config',
+        u'-api',
+        u'QuickTimeUTC',
+        u'-config',
         u'"{}"'.format(constants.exiftool_config)
     ]
     with ExifTool(executable_=get_exiftool(), addedargs=exiftool_addedargs) as et:


### PR DESCRIPTION
According to the EXIF and QuickTime standard, photos should be stored in local time while videos should be stored in UTC time. Since many cameras don't respect this standard, exiftool ignores it by default. However, by adding -api QuickTimeUTC to the exiftool command, the dates are handled appropriately.

From my three cameras:
1. Pixel respects standard
2. Sony a6000 respects standard
3. iPhone does not respect standard

It seems like it should be added as an option to `elodie import` but there would need to be some mechanism to remember the choice when updating.

Endgame would be to automatically switch the flag based on camera make.