### PR TITLE
Add '%extension' to the file custom template

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -282,11 +282,11 @@ By default the resulting filename is all lowercased. To change this behavior to 
 ```
 [File]
 date=%Y-%m-%b-%H-%M-%S
-name=%date-%original_name-%title.jpg
+name=%date-%original_name-%title.%extension
 # -> 2012-05-mar-12-59-30-dsc_1234-my-title.jpg
 
 date=%Y-%m-%b-%H-%M-%S
-name=%date-%original_name-%album.jpg
+name=%date-%original_name-%album.%extension
 capitalization=upper
 # -> 2012-05-MAR-12-59-30-DSC_1234-MY-ALBUM.JPG
 ```


### PR DESCRIPTION
### Context
If the user defines a custom format for the files using the template in the readme will get broken files.

### Examples
Current template
```
[File]
date=%Y-%m-%b-%H-%M-%S
name=%date-%original_name-%title.jpg
```
 
If the original files are all `.jpg` or `.jpeg` will work fine. But other files such as `.mp4` or `.png` will be created with the `.jpeg` extension.

If the template misses any extension for that matter, fill fail too.

Current template without fixed extension
```
[File]
date=%Y-%m-%b-%H-%M-%S
name=%date-%original_name-%title
```
Fill generate each file without extension no matter what. 

### Solution
Always define the template with the `%extension` block.
```
[File]
date=%Y-%m-%b-%H-%M-%S
name=%date-%original_name-%title.%extension
```

### For further steps:
Maybe would be a nice thing to have some kind of validator of the template defined or maybe append de `%extension` by default if the user missed to define it.