### PR TITLE
Update requirements.txt to install Pillow version based on python_version and upgrade six to 1.9 (#393)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ Send2Trash==1.3.0
 future==0.16.0
 configparser==3.5.0
 tabulate==0.7.7
-Pillow==5.3.0
-six==1
+Pillow==6.2.2; python_version == '2.7'
+Pillow==8.0; python_version >= '3.6'
+six==1.9


### PR DESCRIPTION
Fixes #393 which resulted in build errors due to changes in pip.