### PR TITLE
Introduce skipping

### DIFF
--- a/elodie/filesystem.py
+++ b/elodie/filesystem.py
@@ -528,7 +528,6 @@ class FileSystem(object):
             return
 
         checksum = self.process_checksum(_file, allow_duplicate)
-        
         if(checksum is None):
             log.info('Original checksum returned None for %s. Skipping...' %
                      _file)

--- a/elodie/filesystem.py
+++ b/elodie/filesystem.py
@@ -528,10 +528,11 @@ class FileSystem(object):
             return
 
         checksum = self.process_checksum(_file, allow_duplicate)
+        
         if(checksum is None):
             log.info('Original checksum returned None for %s. Skipping...' %
                      _file)
-            return
+            return 'skipped'
 
         # Run `before()` for every loaded plugin and if any of them raise an exception
         #  then we skip importing the file and log a message.

--- a/elodie/result.py
+++ b/elodie/result.py
@@ -8,15 +8,19 @@ class Result(object):
         self.success = 0
         self.error = 0
         self.error_items = []
+        self.skipped = 0
 
     def append(self, row):
         id, status = row
 
-        if status:
-            self.success += 1
+        if status == 'skipped':
+            self.skipped += 1
         else:
-            self.error += 1
-            self.error_items.append(id)
+            if status:
+                self.success += 1
+            else:
+                self.error += 1
+                self.error_items.append(id)
 
     def write(self):
         if self.error > 0:
@@ -33,6 +37,7 @@ class Result(object):
         result = [
                     ["Success", self.success],
                     ["Error", self.error],
+                    ["Skipped", self.skipped],
                  ]
 
         print("****** SUMMARY ******")


### PR DESCRIPTION
# Why

I have a specific use case where I want to run Elodie's import on a schedule (through cron) on a folder where my mobile phone syncs taken pictures to. I want the pictures to stay in the synced folder but want to run Elodie nightly to process any new pictures into my main picture library (which is already sorted by Elodie).

Currently Elodie already skips pictures that are already present in the library. You can see this happen by running Elodie with the `--verbose` flag. These skipped pictures are however counted as errors in the `Result` object. I would argue that a failure to import a picture because it is a duplicate should not be counted as an error but rather as a notice, or in my implementation, a 'skip'.

# What
I have coded a quick and dirty proof of concept of the behavior i'd like to have: When a picture is detected as duplicate it is being skipped, as was the default behavior, but the skip is counted as an actual skip in the `Result` and not as an error.

I am considering creating an additional PR that returns a non-zero status code when `Result` contains `>1` error. That would mean however that i'd have to review all other instances where something is counted as error, and decide if it would be considered a 'skip' (which does not trigger the return of a nonzero status code) or that we'd have to add another counter in `Result` (I am thinking of 'warning' or 'notice', which might supersede 'skip' althogether).

I believe this changes will make Elodie more suitable to be run in automated environments. I could have my cronjob or script decide whether or not a message needs to be sent to the server admin (me) to intervene in case of an actual error.

# Request for comments
I'd like to ask about your opinions on this solution and how we can perfect it.