### PR TITLE
Fix date offset application for videos

### DIFF
--- a/elodie/media/video.py
+++ b/elodie/media/video.py
@@ -91,9 +91,9 @@ class Video(Media):
                                 offset_seconds = int(offset_parts[0]) * 3600
                                 offset_seconds = offset_seconds + int(offset_parts[1]) * 60  # noqa
                                 if date_offset[0] == '-':
-                                    seconds_since_epoch - offset_seconds
+                                    seconds_since_epoch -= offset_seconds
                                 elif date_offset[0] == '+':
-                                    seconds_since_epoch + offset_seconds
+                                    seconds_since_epoch += offset_seconds
                     except:
                         pass
 


### PR DESCRIPTION
While using Elodie to sort some videos, I found that it would consistently move videos' time taken by the same amount as my timezone's offset from UTC. This caused some videos to be placed in the wrong folder.

I noticed that `video.py` has some code dedicated to calculating an date offset, but that this offset is never applied because of some missing `=` signs. I assume that this is an oversight since the affected code doesn't really do anything at the moment.

Adding the `=` signs fixes the issue for me, and Elodie now correctly sorts my files.