### PR TITLE
Python 3.10 Compatibility

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,9 @@ apt-get install libimage-exiftool-perl
 # Fedora / Redhat
 dnf install perl-Image-ExifTool
 
+# Windows (uses chocolatey, https://chocolatey.org/)
+choco install exiftool
+
 # Windows users can install the binary
 # http://www.sno.phy.queensu.ca/~phil/exiftool/install.html
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 click==6.6
 requests==2.20.0
 Send2Trash==1.3.0
-future==0.16.0
+future==0.16.0; python_version < '3.10'
+future==0.18.3; python_version >= '3.10'
 configparser==3.5.0
-tabulate==0.7.7
+tabulate==0.7.7; python_version < '3.10'
+tabulate==0.9.0; python_version >= '3.10'
 Pillow==6.2.2; python_version == '2.7'
 Pillow==9.3; python_version >= '3.6'
 six==1.9


### PR DESCRIPTION
Conditional upgrade of `future` to `v0.18.3` and `tabulate` to `v0.9.0` if and only if python version is > `v3.10`. This fixes the error "ImportError: cannot import name 'Iterable' from 'collections' in Python" on Python 3.10 and higher.

Tested on Ubuntu 22.04.2 LTS:
```
$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.2 LTS
Release:        22.04
Codename:       jammy
```

with `python` version 3.10.6 and `pip` version 22.0.2