### PR TITLE
bump base version. grab latest exif.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,20 @@
-FROM debian:jessie
-
+FROM debian:bullseye
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends ca-certificates libimage-exiftool-perl python2.7 python-pip python-pyexiv2 wget make && \
-    pip install --upgrade pip setuptools && \
+RUN apt-get update -y -qq 
+# removed python-pyexiv2 from this
+RUN apt-get install -y --no-install-recommends ca-certificates libimage-exiftool-perl python2.7 python3 python3-pip wget make
+RUN ln -s /usr/bin/pip3 /usr/bin/python-pip
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
+
+#python-pyexiv2 won't be installed by apt-get. has to be mnaully compiled. with these steps.
+# RUN apt-get install -y python-dev libexiv2-dev cmake git 
+#RUN mkdir /repo && cd /repo && git clone https://github.com/Leo91231/pyexiv2.git
+#RUN cd /repo/pyexiv2 && mkdir build && cd build && cmake .. && make && make install && pip install pyexiv2
+
+#RUN mkdir /repos && cd /repos && git clone https://github.com/OlegIlyenko/py3exiv2.git && cd py3exiv2 && python setup.py install 
+RUN pip install --upgrade pip setuptools && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
@@ -18,11 +28,11 @@ RUN apt-get update -qq && \
 ENV LANG C.UTF-8
 ENV LANGUAGE C.UTF-8
 ENV LC_ALL C.UTF-8
-
-RUN wget http://www.sno.phy.queensu.ca/~phil/exiftool/Image-ExifTool-10.20.tar.gz && \
-    gzip -dc Image-ExifTool-10.20.tar.gz  | tar -xf - && \
-    cd Image-ExifTool-10.20 && perl Makefile.PL && \
-    make install && cd ../ && rm -r Image-ExifTool-10.20
+#follwing https://exiftool.org/install.html#Unix
+RUN wget https://exiftool.org/Image-ExifTool-12.69.tar.gz && \
+    gzip -dc Image-ExifTool-12.69.tar.gz  | tar -xf - && \
+    cd Image-ExifTool-12.69 && perl Makefile.PL && \
+    make install 
 
 COPY requirements.txt /opt/elodie/requirements.txt
 COPY docs/requirements.txt /opt/elodie/docs/requirements.txt


### PR DESCRIPTION
Adding updates to dockerfile. Debian Jessie errors with things like 'apt-update' due to security reasons.  And added other updates, e.g. pulling the latest exiftool, from a working URL. 