### PR TITLE
Fix failing CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,9 @@ jobs:
             pip install -r elodie/plugins/googlephotos/requirements.txt
             pip install coveralls
             sed -i.bak 's/debug = False/debug = True/g' elodie/constants.py
-            wget https://exiftool.org/Image-ExifTool-12.50.tar.gz
-            gzip -dc Image-ExifTool-12.50.tar.gz  | tar -xf -
-            cd Image-ExifTool-12.50
+            wget https://exiftool.org/Image-ExifTool-12.81.tar.gz
+            gzip -dc Image-ExifTool-12.81.tar.gz  | tar -xf -
+            cd Image-ExifTool-12.81
             perl Makefile.PL
             sudo make install
             echo "which exiftool command"

--- a/elodie/tests/run_tests.py
+++ b/elodie/tests/run_tests.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
         config_contents = f.read()
 
     # set the mapquest key in the temporary config file and write it to the temporary application directory
-    config_contents = config_contents.replace('your-api-key-goes-here', 'x8wQLqGhW7qK3sFpjYtVTogVtoMK0S8s')
+    config_contents = config_contents.replace('your-api-key-goes-here', os.environ['MAPQUEST_KEY'])
     with open(temporary_config_file, 'w+') as f:
         f.write(config_contents)
 


### PR DESCRIPTION
Exiftool URL started returning a 404 so switch to URL of newer version.
Make MapQuest key dynamic and store in CircleCI environment.