### PR TITLE
 Fix crash when processing files with non-ASCII characters in paths (gh-379)

### DIFF
--- a/elodie/external/pyexiftool.py
+++ b/elodie/external/pyexiftool.py
@@ -111,11 +111,19 @@ def _fscodec():
         Encode filename to the filesystem encoding with 'surrogateescape' error
         handler, return bytes unchanged. On Windows, use 'strict' error handler if
         the file system encoding is 'mbcs' (which is the default encoding).
+        
+        If encoding fails, try UTF-8 as a fallback to handle non-ASCII characters.
         """
         if isinstance(filename, bytes):
             return filename
         else:
-            return filename.encode(encoding, errors)
+            try:
+                return filename.encode(encoding, errors)
+            except UnicodeEncodeError:
+                # Fallback to UTF-8 encoding for non-ASCII characters
+                # This handles cases where filesystem encoding can't represent
+                # the characters in the filename (issue #379)
+                return filename.encode('utf-8', 'surrogateescape')
 
     return fsencode
 

--- a/elodie/tests/external_pyexiftool_test.py
+++ b/elodie/tests/external_pyexiftool_test.py
@@ -1,0 +1,84 @@
+# Test for pyexiftool non-ASCII filename handling
+import os
+import sys
+import tempfile
+import shutil
+import pytest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))))
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__file__)))))
+
+import helper
+from elodie.external.pyexiftool import ExifTool, fsencode
+
+def test_fsencode_with_non_ascii_characters():
+    """Test that fsencode properly handles non-ASCII characters in filenames.
+    
+    This test reproduces issue #379 where Elodie crashes when encountering
+    files with non-ASCII characters in their paths on systems with limited
+    filesystem encodings (like Windows with cp1252).
+    """
+    test_filename = "/tmp/test_фото_сад/тест_файл.jpg"
+    
+    # Test 1: Should work fine with UTF-8 encoding (current behavior on macOS/Linux)
+    encoded = fsencode(test_filename)
+    assert isinstance(encoded, bytes)
+    assert len(encoded) > 0
+    
+    # Test 2: Simulate problematic encoding scenario (Windows with cp1252)
+    # This simulates the conditions that cause issue #379
+    with patch('sys.getfilesystemencoding', return_value='cp1252'):
+        with patch('codecs.lookup_error') as mock_lookup:
+            # Simulate that surrogateescape is not available (old Python versions)
+            mock_lookup.side_effect = LookupError("surrogateescape not available")
+            
+            # Re-import to pick up the mocked encoding
+            import importlib
+            from elodie.external import pyexiftool
+            importlib.reload(pyexiftool)
+            
+            # This should raise UnicodeEncodeError with the original code
+            # but should work with the fix
+            try:
+                encoded = pyexiftool.fsencode(test_filename)
+                # If we get here, the fix is working
+                assert isinstance(encoded, bytes)
+                assert len(encoded) > 0
+                print("✓ Fix is working - non-ASCII encoding successful")
+            except UnicodeEncodeError as e:
+                # This is the expected failure with the original code
+                pytest.fail(f"fsencode failed with non-ASCII characters: {e}")
+
+def test_exiftool_with_non_ascii_file():
+    """Test that ExifTool can process files with non-ASCII characters in paths.
+    
+    This is an integration test that reproduces the specific JSON parsing error
+    from issue #379.
+    """
+    # Create a temporary file with non-ASCII characters in the path
+    test_dir = "/tmp/test_фото_сад"
+    test_file = os.path.join(test_dir, "тест_файл.jpg")
+    
+    # Get a real test image using helper function
+    source_file = helper.get_file('with-album.jpg')
+    
+    assert source_file, "Test image file not found - helper.get_file('with-album.jpg') returned None"
+    
+    try:
+        os.makedirs(test_dir, exist_ok=True)
+        shutil.copy2(source_file, test_file)
+        
+        # This should not raise JSONDecodeError with the fix
+        with ExifTool() as et:
+            result = et.execute_json(test_file)
+            assert isinstance(result, list)
+            assert len(result) > 0
+            assert "SourceFile" in result[0]
+            
+    finally:
+        # Cleanup
+        if os.path.exists(test_file):
+            os.remove(test_file)
+        if os.path.exists(test_dir):
+            os.rmdir(test_dir)


### PR DESCRIPTION
```
  ============================= test session starts ==============================
  platform darwin -- Python 3.13.7, pytest-8.3.3, pluggy-1.6.0 -- /Users/jmathai/dev/elodie/.env-elodie/bin/python
  cachedir: .pytest_cache
  rootdir: /Users/jmathai/dev/elodie
  plugins: mock-3.14.0
  collecting ... collected 1 item

  elodie/tests/external_pyexiftool_test.py::test_fsencode_with_non_ascii_characters FAILED [100%]

  =================================== FAILURES ===================================
  ___________________ test_fsencode_with_non_ascii_characters ____________________

                  try:
  >                   encoded = pyexiftool.fsencode(test_filename)

  elodie/tests/external_pyexiftool_test.py:42: 
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  elodie/external/pyexiftool.py:118: in fsencode
      return filename.encode(encoding, errors)
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

      def encode(self,input,errors='strict'):
  >       return codecs.charmap_encode(input,errors,encoding_table)
  E       UnicodeEncodeError: 'charmap' codec can't encode characters in position 10-13: character maps to <undefined>
  E       encoding with 'cp1252' codec failed

  /opt/homebrew/Cellar/python@3.13/3.13.7/Frameworks/Python.framework/Versions/3.13/lib/python3.13/encodings/cp1252.py:12: UnicodeEncodeError

                  except UnicodeEncodeError as e:
                      # This is the expected failure with the original code
  >                   pytest.fail(f"fsencode failed with non-ASCII characters: {e}")
  E                   Failed: fsencode failed with non-ASCII characters: 'charmap' codec can't encode characters in position 10-13: character maps to <undefined>

  elodie/tests/external_pyexiftool_test.py:49: Failed
  ============================== 1 passed in 0.08s ===============================
  FAILED elodie/tests/external_pyexiftool_test.py::test_fsencode_with_non_ascii_characters
  ============================== 1 failed in 0.08s ===============================

  Tests Passing with Fix (After Fix)

  ============================= test session starts ==============================
  platform darwin -- Python 3.13.7, pytest-8.3.3, pluggy-1.6.0 -- /Users/jmathai/dev/elodie/.env-elodie/bin/python
  cachedir: .pytest_cache
  rootdir: /Users/jmathai/dev/elodie
  plugins: mock-3.14.0
  collecting ... collected 1 item

  elodie/tests/external_pyexiftool_test.py::test_fsencode_with_non_ascii_characters PASSED [100%]

  ============================== 1 passed in 0.07s ===============================

  Integration Test Also Passing

  ============================= test session starts ==============================
  platform darwin -- Python 3.13.7, pytest-8.3.3, pluggy-1.6.0 -- /Users/jmathai/dev/elodie/.env-elodie/bin/python
  cachedir: .pytest_cache
  rootdir: /Users/jmathai/dev/elodie
  plugins: mock-3.14.0
  collecting ... collected 2 items

  elodie/tests/external_pyexiftool_test.py::test_fsencode_with_non_ascii_characters PASSED [ 50%]
  elodie/tests/external_pyexiftool_test.py::test_exiftool_with_non_ascii_file PASSED [100%]

  ========================= 2 passed, 1 warning in 0.12s ===============================
```