### PR TITLE
Update Pillow for Python 3 builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ future==0.16.0
 configparser==3.5.0
 tabulate==0.9.0
 Pillow==6.2.2; python_version == '2.7'
-Pillow==10.4.0; python_version >= '3.6'
+Pillow==12.1.0; python_version >= '3.6'
 six>=1.16.0
 piexif


### PR DESCRIPTION
  ## Summary
  Updates Python 3 Pillow requirement in `requirements.txt`:
  - `Pillow==10.4.0` -> `Pillow==12.1.0`

  ## Why
  Newer environments (including Python 3.14 setups) require a newer Pillow version to install and run reliably.

  ## Scope
  - Minimal dependency-only change.
  - No runtime logic changes.

  ## Validation
  - Ran project tests in my local environment (with known network-dependent tests excluded in sandboxed runs).
