### PR TITLE
Tidy and modernize flaky/legacy tests

### DIFF
--- a/elodie/tests/external_pyexiftool_test.py
+++ b/elodie/tests/external_pyexiftool_test.py
@@ -69,12 +69,11 @@ def test_exiftool_with_non_ascii_file():
         os.makedirs(test_dir, exist_ok=True)
         shutil.copy2(source_file, test_file)
         
-        # This should not raise JSONDecodeError with the fix
-        with ExifTool() as et:
-            result = et.execute_json(test_file)
-            assert isinstance(result, list)
-            assert len(result) > 0
-            assert "SourceFile" in result[0]
+        # Use the test-session ExifTool process from conftest.py.
+        result = ExifTool().execute_json(test_file)
+        assert isinstance(result, list)
+        assert len(result) > 0
+        assert "SourceFile" in result[0]
             
     finally:
         # Cleanup

--- a/elodie/tests/filesystem_test.py
+++ b/elodie/tests/filesystem_test.py
@@ -20,21 +20,8 @@ from elodie.media.media import Media
 from elodie.media.photo import Photo
 from elodie.media.video import Video
 import pytest
-from elodie.external.pyexiftool import ExifTool
-from elodie.dependencies import get_exiftool
-from elodie import constants
 
 os.environ['TZ'] = 'GMT'
-
-def setup_module():
-    exiftool_addedargs = [
-            u'-config',
-            u'"{}"'.format(constants.exiftool_config)
-        ]
-    ExifTool(executable_=get_exiftool(), addedargs=exiftool_addedargs).start()
-
-def teardown_module():
-    ExifTool().terminate
 
 def test_create_directory_success():
     filesystem = FileSystem()

--- a/elodie/tests/media/audio_test.py
+++ b/elodie/tests/media/audio_test.py
@@ -16,21 +16,8 @@ import helper
 from elodie.media.media import Media
 from elodie.media.video import Video
 from elodie.media.audio import Audio
-from elodie.external.pyexiftool import ExifTool
-from elodie.dependencies import get_exiftool
-from elodie import constants
 
 os.environ['TZ'] = 'GMT'
-
-def setup_module():
-    exiftool_addedargs = [
-            u'-config',
-            u'"{}"'.format(constants.exiftool_config)
-        ]
-    ExifTool(executable_=get_exiftool(), addedargs=exiftool_addedargs).start()
-
-def teardown_module():
-    ExifTool().terminate
 
 def test_audio_extensions():
     audio = Audio()

--- a/elodie/tests/media/base_test.py
+++ b/elodie/tests/media/base_test.py
@@ -23,9 +23,6 @@ from elodie.media.video import Video
 
 os.environ['TZ'] = 'GMT'
 
-setup_module = helper.setup_module
-teardown_module = helper.teardown_module
-
 def test_get_all_subclasses():
     subclasses = get_all_subclasses(Base)
     expected = {Media, Base, Text, Photo, Video, Audio}

--- a/elodie/tests/media/media_test.py
+++ b/elodie/tests/media/media_test.py
@@ -21,9 +21,6 @@ from elodie.media.video import Video
 
 os.environ['TZ'] = 'GMT'
 
-setup_module = helper.setup_module
-teardown_module = helper.teardown_module
-
 def test_get_file_path():
     media = Media(helper.get_file('plain.jpg'))
     path = media.get_file_path()

--- a/elodie/tests/plugins/googlephotos/googlephotos_test.py
+++ b/elodie/tests/plugins/googlephotos/googlephotos_test.py
@@ -30,9 +30,6 @@ config_string_fmt = config_string.format(
     secrets_file
 )
 
-setup_module = helper.setup_module
-teardown_module = helper.teardown_module
-
 @mock.patch('elodie.config.get_config_file', return_value='%s/config.ini-googlephotos-set-session' % gettempdir())
 def test_googlephotos_set_session(mock_get_config_file):
     with open(mock_get_config_file.return_value, 'w') as f:


### PR DESCRIPTION
## Summary
  Cleans up legacy test patterns and test setup noise to improve reliability and signal quality.

  ## Changes
  - Reworks legacy/yield-style test usage into modern pytest-compatible structure.
  - Removes redundant test setup behavior that caused repeated ExifTool start warnings.
  - General test hygiene updates in media/filesystem/plugin test modules.

  ## Why
  This reduces warning noise and improves maintainability without changing runtime behavior.

  ## Scope
  - Tests only.
  - No production code behavior changes intended.

  - Local test run passed with expected skips/xfails.