### PR TITLE
Add MKV video format support

### DIFF
--- a/elodie/media/video.py
+++ b/elodie/media/video.py
@@ -28,7 +28,7 @@ class Video(Media):
     __name__ = 'Video'
 
     #: Valid extensions for video files.
-    extensions = ('avi', 'm4v', 'mov', 'mp4', 'mpg', 'mpeg', '3gp', 'mts')
+    extensions = ('avi', 'm4v', 'mov', 'mp4', 'mpg', 'mpeg', '3gp', 'mts', 'mkv')
 
     def __init__(self, source=None):
         super(Video, self).__init__(source)

--- a/elodie/tests/media/video_test.py
+++ b/elodie/tests/media/video_test.py
@@ -26,6 +26,7 @@ def test_video_extensions():
     assert 'mov' in extensions
     assert 'm4v' in extensions
     assert '3gp' in extensions
+    assert 'mkv' in extensions
 
     valid_extensions = Video.get_valid_extensions()
 


### PR DESCRIPTION
## Summary
  Adds `.mkv` to supported video extensions.

  - Add `mkv` to `Video.extensions` in `elodie/media/video.py`.

## Testing and expectations

  - Ran tests with the project’s Python environment:
    - `python3 -m pytest elodie/tests`
    - Result: `333 passed, 4 skipped, 1 xfailed` (warnings only).
  - Also validated the directly affected tests:
    - `python3 -m pytest elodie/tests/media/video_test.py -v`

  Notes:
  - This PR is intentionally minimal (adds `.mkv` extension support + corresponding test update).
  - Full-suite behavior with very new `pytest` versions can differ on legacy tests in the base branch; this change does not modify those areas.