### PR TITLE
Fix compatibility typo in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -428,7 +428,7 @@ When I organize photos I look at the embedded metadata. Here are the details of 
 | Location (video, audio) | XMP:GPSLatitude, Composite:GPSLatitude, XMP:GPSLongitude, Composite:GPSLongitude | Composite tags are read-only |
 | Title (photo) | XMP:Title |   |
 | Title (video, audio) | XMP:DisplayName |   |
-| Album | XMP-xmpDM:Album, XMP:Album | XMP:Album is user defined in `configs/ExifTool_config` for backwards compatability |
+| Album | XMP-xmpDM:Album, XMP:Album | XMP:Album is user defined in `configs/ExifTool_config` for backwards compatibility |
 | Camera Make (photo, video) | EXIF:Make, QuickTime:Make |   |
 | Camera Model (photo, video) | EXIF:Model, QuickTime:Model |   |
 


### PR DESCRIPTION
Fixes a small README typo: compatability -> compatibility.

No code changes.