### PR TITLE
docs: fix compatibility spelling in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -428,7 +428,7 @@ When I organize photos I look at the embedded metadata. Here are the details of 
 | Location (video, audio) | XMP:GPSLatitude, Composite:GPSLatitude, XMP:GPSLongitude, Composite:GPSLongitude | Composite tags are read-only |
 | Title (photo) | XMP:Title |   |
 | Title (video, audio) | XMP:DisplayName |   |
-| Album | XMP-xmpDM:Album, XMP:Album | XMP:Album is user defined in `configs/ExifTool_config` for backwards compatability |
+| Album | XMP-xmpDM:Album, XMP:Album | XMP:Album is user defined in `configs/ExifTool_config` for backwards compatibility |
 | Camera Make (photo, video) | EXIF:Make, QuickTime:Make |   |
 | Camera Model (photo, video) | EXIF:Model, QuickTime:Model |   |
 


### PR DESCRIPTION
Changes:
- `compatability` -> `compatibility` in `Readme.md` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
