### PR TITLE
fix: correct typo in Readme.md (compatability → compatibility)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -428,7 +428,7 @@ When I organize photos I look at the embedded metadata. Here are the details of 
 | Location (video, audio) | XMP:GPSLatitude, Composite:GPSLatitude, XMP:GPSLongitude, Composite:GPSLongitude | Composite tags are read-only |
 | Title (photo) | XMP:Title |   |
 | Title (video, audio) | XMP:DisplayName |   |
-| Album | XMP-xmpDM:Album, XMP:Album | XMP:Album is user defined in `configs/ExifTool_config` for backwards compatability |
+| Album | XMP-xmpDM:Album, XMP:Album | XMP:Album is user defined in `configs/ExifTool_config` for backwards compatibility |
 | Camera Make (photo, video) | EXIF:Make, QuickTime:Make |   |
 | Camera Model (photo, video) | EXIF:Model, QuickTime:Model |   |
 


### PR DESCRIPTION
## Summary

Fixed a typo in the Readme.md file:

- **Line 431**: `backwards compatability` → `backwards compatibility`

This is a simple spelling correction in the metadata mapping table section, under the Album field description.

## Changes

- `Readme.md`: Corrected "compatability" to "compatibility"